### PR TITLE
Correction in trigger variables to match CI_COMMIT_REF_SLUG definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ dag:
   jeromerobert/bar/master:
   - jeromerobert/foo/master
 we_only: testfull.*
+email:bob@zboub.com
 ```
 
 then run `gitlab-ci-sched`
@@ -46,3 +47,5 @@ to avoid doublon in pipeline creation.
 
 To use the `we_only` set your jobs as `when: manual` and they'll be
 run only during on saturday or sunday.
+
+email: the mail adress given will be passed to the jobs as trigger vairable 'GITLAB_USER_EMAIL'

--- a/gitlabci_sched/__init__.py
+++ b/gitlabci_sched/__init__.py
@@ -171,6 +171,8 @@ class Scheduler(object):
         r = {}
         for p_name, branch in self.dag.predecessors(project):
             r['CI_REF_' + p_name.upper().replace('/', '_')] = re.sub('\W', '-', branch.lower() )
+        if 'email' in self.config:
+            r['GITLAB_USER_EMAIL'] = self.config['email']
         return r
 
     def __run_new_pipeline(self, project):

--- a/gitlabci_sched/__init__.py
+++ b/gitlabci_sched/__init__.py
@@ -165,10 +165,12 @@ class Scheduler(object):
         return result
 
     def __trigger_variables(self, project):
-        """ Return variables for a trigger to describe the dependencies """
+        """ Return variables for a trigger to describe the dependencies
+            Should be built like the CI_COMMIT_REF_SLUG variable defined here:
+            https://gitlab.com/help/ci/variables/README.md#predefined-variables-environment-variables """
         r = {}
         for p_name, branch in self.dag.predecessors(project):
-            r['CI_REF_' + p_name.upper().replace('/', '_')] = branch
+            r['CI_REF_' + p_name.upper().replace('/', '_')] = re.sub('\W', '-', branch.lower() )
         return r
 
     def __run_new_pipeline(self, project):

--- a/gitlabci_sched/__init__.py
+++ b/gitlabci_sched/__init__.py
@@ -240,10 +240,10 @@ class YamlScheduler(Scheduler):
         with open(yaml_file) as f:
             self.config = yaml.load(f)
             Scheduler.__init__(self, self.config['server']['url'], self.config['server']['token'])
-        if 'only_we' in self.config:
-            self.only_we = re.compile(self.config['only_we'])
+        if 'we_only' in self.config:
+            self.we_only = re.compile(self.config['we_only'])
         else:
-            self.only_we = None
+            self.we_only = None
 
     def __parse_project(self, name):
         m = self.PROJECT_REGEX.match(name)
@@ -271,9 +271,9 @@ class YamlScheduler(Scheduler):
         time.sleep(30)
 
     def _can_run_manual(self, project, job):
-        return self.only_we is not None \
+        return self.we_only is not None \
             and datetime.datetime.today().weekday() >= 5 \
-            and self.only_we.match(job)
+            and self.we_only.match(job)
 
 def main():
     logging.basicConfig(level=logging.INFO, format='[%(asctime)s] %(message)s', datefmt='%m/%d/%Y %H:%M:%S')


### PR DESCRIPTION
The trigger variables should be built like the CI_COMMIT_REF_SLUG variable defined here: https://gitlab.com/help/ci/variables/README.md#predefined-variables-environment-variables
that is to say : lowercased, shortened to 63 bytes, and with everything except 0-9 and a-z replaced with -. No leading / trailing -.
I just implemented: lowercased, with everything except 0-9 and a-z replaced with -. 